### PR TITLE
Removes inference files deletion for auditing purposes.

### DIFF
--- a/src/core/services/message_listener_service.py
+++ b/src/core/services/message_listener_service.py
@@ -61,7 +61,7 @@ async def listen_for_messages_and_update(
         logging.info("update received.")
         _update_database(database_port, result_update)
 
-        simple_storage_port.remove_inference_directory(result_update.inference_id)
+        # simple_storage_port.remove_inference_directory(result_update.inference_id)
 
     except LogicException:
         raise

--- a/tests/unit_tests/services/test_message_listener_service.py
+++ b/tests/unit_tests/services/test_message_listener_service.py
@@ -84,4 +84,4 @@ def test_listen_for_messages_and_update(
         mock_update_inference_status.assert_called_once_with(
             "fake_inference_id", Status.completed_status
         )
-        mock_remove_inference_directory.assert_called_once_with("fake_inference_id")
+        # mock_remove_inference_directory.assert_called_once_with("fake_inference_id")


### PR DESCRIPTION
-Purpose:

Audio files should not be deleted after an inference for auditing purposes.