### PR TITLE
Bumping poetry to 1.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.8 as base
 
 ENV POETRY_VERSION=1.3.2
 
+RUN apt update
+RUN apt install jq -y
 RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #base image
 FROM python:3.8 as base
 
-ENV POETRY_VERSION=1.1.13
+ENV POETRY_VERSION=1.3.2
 
 RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pytest-asyncio = "^0.19.0"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=1.1.13"]
+requires = ["poetry>=1.3.2"]
 build-backend = "poetry.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Motivation

SPIRA-API is currently using poetry@1.1.12. This breaks the docker build with the following error:

'''

vguidi@Pato:~/Desktop/SPIRA-API$ poetry add urllib3==1.26.15

  AttributeError

  'HTTPResponse' object has no attribute 'strict'

  at ~/.local/pipx/venvs/poetry/lib/python3.10/site-packages/cachecontrol/serialize.py:54 in dumps
       50│                 ),
       51│                 u"status": response.status,
       52│                 u"version": response.version,
       53│                 u"reason": text_type(response.reason),
    →  54│                 u"strict": response.strict,
       55│                 u"decode_content": response.decode_content,
       56│             }
       57│         }
       58│
'''

The docker image for the API also does not have jq, which breaks the system tests

### Fix

Bumped poetry version to 1.3.2
added apt update / apt install jq to dockerfile

### Testing

Ran  make all-tests and verified everything went alright
