### PR TITLE
Adding test image creation to CD pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set Env
         run: echo "API_IMAGE=${{ secrets.DOCKER_USERNAME }}/spira-api:${{github.ref_name}}" >> $GITHUB_ENV
+        run: echo "API_TEST_IMAGE=${{ secrets.DOCKER_USERNAME }}/spira-api-test:${{github.ref_name}}" >> $GITHUB_ENV
+
 
       - name: Push Image
         run: bash push-image.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        poetry-version: [1.1.13]
+        poetry-version: [1.3.2]
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +30,7 @@ jobs:
 
       - name: Set Env
         run: echo "API_IMAGE=${{ secrets.DOCKER_USERNAME }}/spira-api" >> $GITHUB_ENV
+        run: echo "API_TEST_IMAGE=${{ secrets.DOCKER_USERNAME }}/spira-api-test:${{github.ref_name}}" >> $GITHUB_ENV
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,18 @@ services:
       - nats-network
       - mongo-network
       - minio-network
+
+  k8s-test-image:
+    build:
+      context: .
+      target: dev
+    image: ${API_TEST_IMAGE}
+    container_name: spira-api-tester-1
+    entrypoint: python3
+    volumes:
+      - ".:/app/"
+    ports:
+      - 3000:8000 
       
   tester:
     build:

--- a/push-image.sh
+++ b/push-image.sh
@@ -2,3 +2,5 @@
 docker compose stop
 docker compose build api
 docker compose push api
+docker compose build k8s-test-image
+docker compose push k8s-test-image


### PR DESCRIPTION
### Motivation

In order to run integration tests on k8s, we need a pod with the integration/system test files.
As we currently have only the prod image on dockerhub, we need to have the test one as well.
This PR implements the creation and upload of the new image.